### PR TITLE
[#175798769] Added start session tests

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -1013,6 +1013,10 @@ paths:
           description: Forbidden
         '404':
           description: Not Found
+        '422':
+          description: Unprocessable Entity
+        '500':
+          description: Generic Error
   '/v3/users/actions/validate-bo-reset-password/{id}':
     get:
       tags:
@@ -2330,6 +2334,8 @@ definitions:
     title: StartSessionDto
   StartSessionRequest:
     type: object
+    required:
+      - email
     properties:
       data:
         $ref: '#/definitions/StartSession'

--- a/src/__integrations__/pagopaApi.server.integration.test.ts
+++ b/src/__integrations__/pagopaApi.server.integration.test.ts
@@ -122,13 +122,15 @@ describe('Payment Manager Client', () => {
   });
 
   it('should return a left either (error 422) when start-session is called with a void payload', async () => {
-    /* const HOST = process.env.PAYMENT_MANAGER_STUB_HOST as string;
+    const HOST = process.env.PAYMENT_MANAGER_STUB_HOST as string;
     const PORT = process.env.PAYMENT_MANAGER_STUB_PORT ? parseInt(process.env.PAYMENT_MANAGER_STUB_PORT, 10) : 5000;
     const pmMockServer = pm.listen(PORT, HOST);
-    const stubServerTerminator = createHttpTerminator({ server: pmMockServer }); */
+    const stubServerTerminator = createHttpTerminator({ server: pmMockServer });
 
+    /*
     const HOST = 'localhost';
     const PORT = 8080;
+    */
 
     const paymentManagerClient = createClient({
       baseUrl: `http://${HOST}:${PORT}`,
@@ -225,11 +227,11 @@ describe('Payment Manager Client', () => {
           },
         })
       ).fold(
-        err => (err.pop()?.value as Response).status,
         () => undefined,
+        myRes => myRes.status,
       ),
     ).toEqual(500);
 
-    // await stubServerTerminator.terminate();
+    await stubServerTerminator.terminate();
   });
 });

--- a/src/__integrations__/pm.ts
+++ b/src/__integrations__/pm.ts
@@ -1,32 +1,39 @@
-// import { debug as cdebug } from 'console';
-
 import { Application, Router } from 'express';
 import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import * as myFake from 'faker/locale/it';
+import { StartSessionRequest } from '../../generated/definitions/pagopa/StartSessionRequest';
 
 // create express server
 const pm: Application = express();
 pm.use(cors());
 pm.use(bodyParser.json());
-
 // Use router to keep the express app extensible
 const walletRouter = Router();
 walletRouter.post('/pp-restapi/v3/users/actions/start-session', function (req, res) {
-  if (req.body.data.email === 'tooManyRequests@pm.com') {
-    res.sendStatus(429);
-  } else {
-    res.json({
-      data: {
-        sessionToken: myFake.random.alphaNumeric(128),
-        user: {
-          email: 'pippo@pluto.com',
-          status: 'ANONYMOUS',
-        },
-      },
-    });
-  }
+  StartSessionRequest.decode(req.body).fold(
+    () => res.sendStatus(500),
+    decodedReq => {
+      if (decodedReq.data?.email === 'tooManyRequests@pm.com') {
+        return res.sendStatus(429);
+      } else if (decodedReq.data && Object.keys(decodedReq.data).length === 0) {
+        return res.sendStatus(422);
+      } else if (!Object.prototype.hasOwnProperty.call(decodedReq.data, 'email')) {
+        return res.sendStatus(500);
+      } else {
+        return res.json({
+          data: {
+            sessionToken: myFake.random.alphaNumeric(128),
+            user: {
+              email: decodedReq.data?.email,
+              status: 'ANONYMOUS',
+            },
+          },
+        });
+      }
+    },
+  );
 });
 
 const routers: ReadonlyArray<Router> = [walletRouter];

--- a/src/__integrations__/pmClient.startSession.integration.test.ts
+++ b/src/__integrations__/pmClient.startSession.integration.test.ts
@@ -1,0 +1,168 @@
+import { Server } from 'http';
+
+import nodeFetch from 'node-fetch';
+// Needed to patch the globals
+import 'abort-controller/polyfill';
+import { createHttpTerminator, HttpTerminator } from 'http-terminator';
+import { Millisecond } from 'italia-ts-commons/lib/units';
+import { createClient } from '../../generated/definitions/pagopa/client';
+import { retryingFetch } from '../utils/fetch';
+import pm from './pm';
+import { OsEnum } from '../../generated/definitions/pagopa/Device';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any,functional/immutable-data
+(global as any).fetch = nodeFetch;
+
+describe('Endpoint startSession', () => {
+  const PORT = process.env.PAYMENT_MANAGER_STUB_PORT ? parseInt(process.env.PAYMENT_MANAGER_STUB_PORT, 10) : 8080;
+  const HOST = process.env.PAYMENT_MANAGER_STUB_HOST as string;
+
+  // eslint-disable-next-line functional/no-let
+  let pmServer: Server;
+
+  // eslint-disable-next-line functional/no-let
+  let pmServerTerminator: HttpTerminator;
+
+  // eslint-disable-next-line functional/no-let
+  let pmClient;
+
+  beforeAll(async () => {
+    // Start server
+    pmServer = pm.listen(PORT, HOST);
+    pmServerTerminator = createHttpTerminator({ server: pmServer });
+    // Start client
+    pmClient = createClient({
+      baseUrl: `http://${HOST}:${PORT}`,
+      fetchApi: retryingFetch(fetch, 5000 as Millisecond, 5),
+    });
+  });
+
+  afterAll(async () => {
+    await pmServerTerminator.terminate();
+  });
+
+  it('should return 500 when the request is empty', async () => {
+    expect(
+      (
+        await pmClient.startSessionUsingPOST({
+          startSessionRequest: {},
+        })
+      ).fold(
+        err => (err.pop()?.value as Response).status,
+        myRes => myRes.status,
+      ),
+    ).toEqual(500);
+  });
+
+  it('should return 422 when the request has an empty data field', async () => {
+    expect(
+      (
+        await pmClient.startSessionUsingPOST({
+          startSessionRequest: {
+            data: {},
+          },
+        })
+      ).fold(
+        err => (err.pop()?.value as Response).status,
+        myRes => myRes.status,
+      ),
+    ).toEqual(422);
+  });
+
+  it("should return the same response when it's called with or without device", async () => {
+    const pmResponse = await pmClient.startSessionUsingPOST({
+      startSessionRequest: {
+        data: {
+          email: 'nunzia.ross@example.com',
+          fiscalCode: 'UQNSFM56P12T733D', // seems to be ignored by PM
+          idPayment: '12345', // seems to be ignored by PM
+        },
+      },
+    });
+
+    const pmResponseWithDevice = await pmClient.startSessionUsingPOST({
+      startSessionRequest: {
+        data: {
+          email: 'nunzia.ross@example.com',
+          idPayment: '12345', // seems to be ignored by PM
+          device: {
+            os: 'ANDROID' as OsEnum,
+          },
+        },
+      },
+    });
+
+    expect(
+      pmResponse.fold(
+        () => undefined,
+        myRes => myRes.value?.data?.user,
+      ),
+    ).toEqual(
+      pmResponseWithDevice.fold(
+        () => undefined,
+        myRes => myRes.value?.data?.user,
+      ),
+    );
+  });
+
+  it('should return ANONYMOUS as user state when she feeds an email', async () => {
+    expect(
+      (
+        await pmClient.startSessionUsingPOST({
+          startSessionRequest: {
+            data: {
+              email: 'nunzia.ross@example.com',
+              fiscalCode: 'UQNSFM56P12T733D', // seems to be ignored by PM
+              idPayment: '12345', // seems to be ignored by PM
+            },
+          },
+        })
+      ).fold(
+        () => undefined,
+        myRes => myRes.value?.data?.user?.status,
+      ),
+    ).toEqual('ANONYMOUS');
+  });
+
+  it('should return a sessionToken when the user feeds an email', async () => {
+    const pmResponse = await pmClient.startSessionUsingPOST({
+      startSessionRequest: {
+        data: {
+          email: 'nunzia.ross@example.com',
+          fiscalCode: 'UQNSFM56P12T733D', // seems to be ignored by PM
+          idPayment: '12345', // seems to be ignored by PM
+        },
+      },
+    });
+    expect(
+      pmResponse.fold(
+        () => undefined,
+        myRes => myRes.value?.data?.sessionToken,
+      ),
+    ).toMatch(/[\d\w]{128}/i);
+
+    expect(
+      pmResponse.fold(
+        () => undefined,
+        myRes => myRes.value?.data?.sessionToken,
+      ),
+    ).not.toMatch(/[\d\w]{129}/i);
+  });
+
+  it("should return 500 when the user doesn't feed an email", async () => {
+    expect(
+      (
+        await pmClient.startSessionUsingPOST({
+          startSessionRequest: {
+            data: {
+              fiscalCode: 'UQNSFM56P12T733D',
+            },
+          },
+        })
+      ).fold(
+        () => undefined,
+        myRes => myRes.status,
+      ),
+    ).toEqual(500);
+  });
+});

--- a/src/__integrations__/pmClient.startSession.integration.test.ts
+++ b/src/__integrations__/pmClient.startSession.integration.test.ts
@@ -7,8 +7,8 @@ import { createHttpTerminator, HttpTerminator } from 'http-terminator';
 import { Millisecond } from 'italia-ts-commons/lib/units';
 import { createClient } from '../../generated/definitions/pagopa/client';
 import { retryingFetch } from '../utils/fetch';
-import pm from './pm';
 import { OsEnum } from '../../generated/definitions/pagopa/Device';
+import pm from './pm';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,functional/immutable-data
 (global as any).fetch = nodeFetch;


### PR DESCRIPTION
This PR proposes a suite of unit tests to asses if the supposed behavior of the PM adheres to specifications. After the tests, the local `api.yml` - modeling PM specs - in updated

#### List of Changes

- `start-session` unit tests
- updated `api.yml` to generate a better client

#### Motivation and Context

This change is required to validate the `start-session` method of the autogenerated PM Client

#### How Has This Been Tested?

Suite of unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
