### PR TITLE
[#175798637] Unit test for getPspListUsingGET - pm client

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -158,7 +158,7 @@ paths:
         - name: paymentType
           in: query
           description: paymentType
-          required: false
+          required: true
           type: string
         - name: paymentModel
           in: query
@@ -166,6 +166,23 @@ paths:
           required: false
           type: integer
           format: int64
+        - name: language
+          in: query
+          description: language
+          required: false
+          type: string  
+          default: it
+        - name: isList
+          in: query
+          description: to return only a result
+          required: false
+          type: boolean  
+          default: false
+        - name: idWallet
+          in: query
+          description: idWallet
+          required: false
+          type: integer
         - name: idPayment
           in: query
           description: idPayment
@@ -178,10 +195,20 @@ paths:
             $ref: '#/definitions/PspListResponse'
         '401':
           description: Unauthorized
-        '403':
-          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         '404':
           description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        '422':
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/ErrorResponse'        
+        '500':
+          description: Generic Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'  
       security:
         - Bearer: []
   '/psps/actions/get-buyer-bank/{idBuyer}':

--- a/src/__integrations__/pm.ts
+++ b/src/__integrations__/pm.ts
@@ -25,6 +25,7 @@ pm.use(bodyParser.json());
 
 // Use router to keep the express app extensible
 const walletRouter = Router();
+const pspsRouter = Router();
 
 const goodIdPayment = '8fa64d75-acb4-4a74-a87c-32f348a6a95f';
 const goodIdWallet = 100;
@@ -361,7 +362,167 @@ walletRouter.get('/pp-restapi/v4/transactions/:id/actions/check', function (req,
   }
 });
 
-const routers: ReadonlyArray<Router> = [walletRouter];
+pspsRouter.get('/pp-restapi/v4/psps', function (req, res) {
+  const enPspsList = {
+    data: {
+      pspList: [
+        {
+          id: 30,
+          idPsp: 'Digital stamp enabled PSP',
+          businessName: 'Poste Inglesi',
+          paymentType: 'CP',
+          idIntermediary: 'BANCOPOSTA',
+          idChannel: 'POSTE1',
+          logoPSP: 'http://pagopa-dev:8080/pp-restapi/v4/resources/psp/30',
+          serviceLogo: 'http://pagopa-dev:8080/pp-restapi/v4/resources/service/30',
+          serviceName: 'poste EN - DS Enabled',
+          fixedCost: { currency: 'EUR', amount: 625, decimalDigits: 2 },
+          appChannel: false,
+          serviceAvailability: 'Pagamento Bollo Digitale tramite Poste',
+          urlInfoChannel: 'http://www.test.sia.eu',
+          paymentModel: 1,
+          flagStamp: true,
+          idCard: 11008,
+          lingua: 'EN',
+          codiceAbi: '06220',
+          isPspOnus: false,
+          directAcquirer: false,
+          solvedByPan: false,
+        },
+      ],
+      myBankSellerBankList: [],
+    },
+  };
+  const firstItPspsList = {
+    data: {
+      pspList: [
+        {
+          id: 8,
+          idPsp: 'POSTE1',
+          businessName: 'Poste Italiane',
+          paymentType: 'CP',
+          idIntermediary: 'BANCOPOSTA',
+          idChannel: 'POSTE1',
+          logoPSP: 'http://pagopa-dev:8080/pp-restapi/v4/resources/psp/8',
+          serviceLogo: 'http://pagopa-dev:8080/pp-restapi/v4/resources/service/8',
+          serviceName: 'nomeServizio 02 poste (MOD0)',
+          fixedCost: { currency: 'EUR', amount: 1, decimalDigits: 2 },
+          appChannel: false,
+          serviceAvailability: 'disponibilitaServizio FRANCESE',
+          urlInfoChannel: 'http://www.test.sia.eu',
+          paymentModel: 0,
+          idCard: 11008,
+          lingua: 'IT',
+          codiceAbi: '06220',
+          isPspOnus: false,
+          directAcquirer: false,
+          solvedByPan: false,
+        },
+      ],
+      myBankSellerBankList: [],
+    },
+  };
+
+  const itPspsList = {
+    data: {
+      pspList: [
+        {
+          id: 8,
+          idPsp: 'POSTE1',
+          businessName: 'Poste Italiane',
+          paymentType: 'CP',
+          idIntermediary: 'BANCOPOSTA',
+          idChannel: 'POSTE1',
+          logoPSP: 'http://pagopa-dev:8080/pp-restapi/v4/resources/psp/8',
+          serviceLogo: 'http://pagopa-dev:8080/pp-restapi/v4/resources/service/8',
+          serviceName: 'nomeServizio 02 poste (MOD0)',
+          fixedCost: { currency: 'EUR', amount: 1, decimalDigits: 2 },
+          appChannel: false,
+          serviceAvailability: 'disponibilitaServizio FRANCESE',
+          urlInfoChannel: 'http://www.test.sia.eu',
+          paymentModel: 0,
+          idCard: 11008,
+          lingua: 'IT',
+          codiceAbi: '06220',
+          isPspOnus: false,
+          directAcquirer: false,
+          solvedByPan: false,
+        },
+        {
+          id: 11,
+          idPsp: 'Digital stamp enabled PSP',
+          businessName: 'Poste Italiane',
+          paymentType: 'CP',
+          idIntermediary: 'BANCOPOSTA',
+          idChannel: 'POSTE1',
+          logoPSP: 'http://pagopa-dev:8080/pp-restapi/v4/resources/psp/11',
+          serviceLogo: 'http://pagopa-dev:8080/pp-restapi/v4/resources/service/11',
+          serviceName: 'poste - DS Enabled',
+          fixedCost: { currency: 'EUR', amount: 625, decimalDigits: 2 },
+          appChannel: false,
+          serviceAvailability: 'Pagamento Bollo Digitale tramite Poste',
+          urlInfoChannel: 'http://www.test.sia.eu',
+          paymentModel: 1,
+          flagStamp: true,
+          idCard: 11008,
+          lingua: 'IT',
+          codiceAbi: '06220',
+          isPspOnus: false,
+          directAcquirer: false,
+          solvedByPan: false,
+        },
+        {
+          id: 22,
+          idPsp: 'NEXI_Visa',
+          businessName: 'Psp NEXI 2',
+          paymentType: 'CP',
+          idIntermediary: 'Psp Nexi',
+          idChannel: 'NEXI (Visa)',
+          logoPSP: 'http://pagopa-dev:8080/pp-restapi/v4/resources/psp/22',
+          serviceLogo: 'http://pagopa-dev:8080/pp-restapi/v4/resources/service/22',
+          serviceName: 'NEXI (Visa)',
+          fixedCost: { currency: 'EUR', amount: 111, decimalDigits: 2 },
+          appChannel: false,
+          serviceAvailability: 'NEXI',
+          paymentModel: 1,
+          flagStamp: true,
+          idCard: 99997,
+          lingua: 'IT',
+          codiceAbi: '99997',
+          isPspOnus: false,
+          directAcquirer: true,
+          solvedByPan: false,
+        },
+      ],
+      myBankSellerBankList: [],
+    },
+  };
+
+  fromPredicate(
+    (myReq: typeof req) => /Bearer [\d\w]{128}/.test(fromNullable(myReq.headers.authorization).getOrElse('')),
+    identity,
+  )(req).fold(
+    () => res.status(401).json({ code: '2000', message: 'Invalid Token' }),
+    () => {
+      const idPayemnt = req.query.idPayment;
+      const isList = req.query.isList;
+      const language = req.query.language;
+      if (idPayemnt === 'xxx') {
+        return res.status(422).json({ code: '0', message: 'Unexpected error' });
+      } else if (isList === 'true' && language === 'it') {
+        return res.json(itPspsList);
+      } else if (isList === 'true' && language === 'en') {
+        return res.json(enPspsList);
+      } else if (isList === 'false' && language === 'it') {
+        return res.json(firstItPspsList);
+      } else {
+        return res.status(500);
+      }
+    },
+  );
+});
+
+const routers: ReadonlyArray<Router> = [walletRouter, pspsRouter];
 routers.forEach(r => pm.use(r));
 
 export default pm;

--- a/src/__integrations__/pmClient.getPsps.integration.test.ts
+++ b/src/__integrations__/pmClient.getPsps.integration.test.ts
@@ -2,6 +2,10 @@ import { Server } from 'http';
 
 import { Millisecond } from 'italia-ts-commons/lib/units';
 
+import * as myFake from 'faker/locale/it';
+
+import { fromNullable } from 'fp-ts/lib/Option';
+
 import nodeFetch from 'node-fetch';
 
 import { createHttpTerminator } from 'http-terminator';
@@ -9,12 +13,10 @@ import { retryingFetch } from '../utils/fetch';
 
 import { Client, createClient } from '../../generated/definitions/pagopa/client';
 
-import * as myFake from 'faker/locale/it';
-
-import pm from './pm';
 import { PspListResponse } from '../../generated/definitions/pagopa/PspListResponse';
 import { Psp } from '../../generated/definitions/pagopa/Psp';
-import { fromNullable } from 'fp-ts/lib/Option';
+
+import pm from './pm';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,functional/immutable-data
 (global as any).fetch = nodeFetch;
@@ -76,6 +78,7 @@ describe('Payment Manager Client to retrive psps', () => {
       _ => fail(),
       res => {
         const pspListResponse: PspListResponse = res.value;
+        // eslint-disable-next-line @typescript-eslint/array-type
         const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
         expect(itPspsList.length).toEqual(3);
         itPspsList.forEach(psp => {
@@ -116,6 +119,7 @@ describe('Payment Manager Client to retrive psps', () => {
       _ => fail(),
       res => {
         const pspListResponse: PspListResponse = res.value;
+        // eslint-disable-next-line @typescript-eslint/array-type
         const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
         expect(itPspsList.length).toEqual(1);
         itPspsList.forEach(psp => {
@@ -156,6 +160,7 @@ describe('Payment Manager Client to retrive psps', () => {
       _ => fail(),
       res => {
         const pspListResponse: PspListResponse = res.value;
+        // eslint-disable-next-line @typescript-eslint/array-type
         const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
         expect(itPspsList.length).toEqual(1);
         itPspsList.forEach(psp => {

--- a/src/__integrations__/pmClient.getPsps.integration.test.ts
+++ b/src/__integrations__/pmClient.getPsps.integration.test.ts
@@ -1,0 +1,222 @@
+import { Server } from 'http';
+
+import { Millisecond } from 'italia-ts-commons/lib/units';
+
+import nodeFetch from 'node-fetch';
+
+import { createHttpTerminator } from 'http-terminator';
+import { retryingFetch } from '../utils/fetch';
+
+import { Client, createClient } from '../../generated/definitions/pagopa/client';
+
+import * as myFake from 'faker/locale/it';
+
+import pm from './pm';
+import { PspListResponse } from '../../generated/definitions/pagopa/PspListResponse';
+import { Psp } from '../../generated/definitions/pagopa/Psp';
+import { fromNullable } from 'fp-ts/lib/Option';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any,functional/immutable-data
+(global as any).fetch = nodeFetch;
+
+// Client for the PagoPA PaymentManager
+describe('Payment Manager Client to retrive psps', () => {
+  const HOST = process.env.PAYMENT_MANAGER_STUB_HOST as string;
+  const PORT = process.env.PAYMENT_MANAGER_STUB_PORT ? parseInt(process.env.PAYMENT_MANAGER_STUB_PORT, 10) : 5000;
+
+  const mySessionToken = myFake.random.alphaNumeric(128);
+
+  // eslint-disable-next-line functional/no-let
+  let pmMockServer: Server;
+
+  // eslint-disable-next-line functional/no-let
+  let paymentManagerClient: Client;
+
+  beforeAll(() => {
+    pmMockServer = pm.listen(PORT, HOST);
+
+    paymentManagerClient = createClient({
+      baseUrl: `http://${HOST}:${PORT}`,
+      fetchApi: retryingFetch(fetch, 5000 as Millisecond, 5),
+    });
+  });
+
+  afterAll(async () => {
+    const stubServerTerminator = createHttpTerminator({ server: pmMockServer });
+    await stubServerTerminator.terminate();
+  });
+
+  it('should return successful response (200) with 3 psps when getPspListUsingGET is invoked for a valid payment with an italian credit card', async () => {
+    const idPayment = 'c69eae39-7de1-40a5-86aa-2bb1b17c7b80';
+    const Bearer = `Bearer ${mySessionToken}`;
+    const paymentType = 'CREDIT_CARD';
+    const isList = true;
+    const language = 'it';
+    const idWallet = 17;
+
+    const response = await paymentManagerClient.getPspListUsingGET({
+      Bearer,
+      paymentType,
+      isList,
+      idWallet,
+      language,
+      idPayment,
+    });
+
+    expect(response.isRight()).toBeTruthy();
+
+    expect(
+      response.fold(
+        _ => fail(),
+        res => res.status,
+      ),
+    ).toEqual(200);
+
+    response.fold(
+      _ => fail(),
+      res => {
+        const pspListResponse: PspListResponse = res.value;
+        const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
+        expect(itPspsList.length).toEqual(3);
+        itPspsList.forEach(psp => {
+          expect(psp.lingua).toEqual('IT'); // italian PSP
+          expect(psp.paymentType).toEqual('CP'); // Credit Card
+        });
+      },
+    );
+  });
+
+  it('should return successful response (200) with 1 psps when getPspListUsingGET is invoked to return the first psp for valid payment with an italian credit card', async () => {
+    const idPayment = 'c69eae39-7de1-40a5-86aa-2bb1b17c7b80';
+    const Bearer = `Bearer ${mySessionToken}`;
+    const paymentType = 'CREDIT_CARD';
+    const isList = false;
+    const language = 'it';
+    const idWallet = 17;
+
+    const response = await paymentManagerClient.getPspListUsingGET({
+      Bearer,
+      paymentType,
+      isList,
+      idWallet,
+      language,
+      idPayment,
+    });
+
+    expect(response.isRight()).toBeTruthy();
+
+    expect(
+      response.fold(
+        _ => fail(),
+        res => res.status,
+      ),
+    ).toEqual(200);
+
+    response.fold(
+      _ => fail(),
+      res => {
+        const pspListResponse: PspListResponse = res.value;
+        const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
+        expect(itPspsList.length).toEqual(1);
+        itPspsList.forEach(psp => {
+          expect(psp.lingua).toEqual('IT'); // italian PSP
+          expect(psp.paymentType).toEqual('CP'); // Credit Card
+        });
+      },
+    );
+  });
+
+  it('should return successful response (200) with 1 psps when getPspListUsingGET is invoked for a valid payment with an english credit card', async () => {
+    const idPayment = 'c69eae39-7de1-40a5-86aa-2bb1b17c7b80';
+    const Bearer = `Bearer ${mySessionToken}`;
+    const paymentType = 'CREDIT_CARD';
+    const isList = true;
+    const language = 'en';
+    const idWallet = 17;
+
+    const response = await paymentManagerClient.getPspListUsingGET({
+      Bearer,
+      paymentType,
+      isList,
+      idWallet,
+      language,
+      idPayment,
+    });
+
+    expect(response.isRight()).toBeTruthy();
+
+    expect(
+      response.fold(
+        _ => fail(),
+        res => res.status,
+      ),
+    ).toEqual(200);
+
+    response.fold(
+      _ => fail(),
+      res => {
+        const pspListResponse: PspListResponse = res.value;
+        const itPspsList: readonly Psp[] = fromNullable(pspListResponse.data?.pspList).getOrElse([]);
+        expect(itPspsList.length).toEqual(1);
+        itPspsList.forEach(psp => {
+          expect(psp.lingua).toEqual('EN'); // italian PSP
+          expect(psp.paymentType).toEqual('CP'); // Credit Card
+        });
+      },
+    );
+  });
+
+  it('should return error response (422)  when getPspListUsingGET is invoked for a invalid payment', async () => {
+    const idPayment = 'xxx';
+    const Bearer = `Bearer ${mySessionToken}`;
+    const paymentType = 'CREDIT_CARD';
+    const isList = true;
+    const language = 'en';
+    const idWallet = 17;
+
+    const response = await paymentManagerClient.getPspListUsingGET({
+      Bearer,
+      paymentType,
+      isList,
+      idWallet,
+      language,
+      idPayment,
+    });
+
+    expect(response.isRight()).toBeTruthy();
+
+    expect(
+      response.fold(
+        _ => fail(),
+        res => res.status,
+      ),
+    ).toEqual(422);
+  });
+
+  it('should return error response (401)  when getPspListUsingGET is invoked with invalid token', async () => {
+    const idPayment = 'xxx';
+    const Bearer = `Bearer tsxc`;
+    const paymentType = 'CREDIT_CARD';
+    const isList = true;
+    const language = 'en';
+    const idWallet = 17;
+
+    const response = await paymentManagerClient.getPspListUsingGET({
+      Bearer,
+      paymentType,
+      isList,
+      idWallet,
+      language,
+      idPayment,
+    });
+
+    expect(response.isRight()).toBeTruthy();
+
+    expect(
+      response.fold(
+        _ => fail(),
+        res => res.status,
+      ),
+    ).toEqual(401);
+  });
+});


### PR DESCRIPTION
#### Description 

The goal of this PR is to add api invocation to get a psps list.

#### List of Changes

- fixed api spec for GET /psps
- added tests;

#### Motivation and Context

The invocation of the following api (Payment Manager):

  - GET /pp-restapi/v4/psps

it is important for io-pay to retrive a psps list given the following filter in query string:
- language
- idWallet
- idPayment
- paymentType
- isList

#### How Has This Been Tested?

- yarn run test
- yarn start (with local [Payment Manager](https://github.com/pagopa/pm-mock))


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
