### PR TITLE
[#175798933] Polling to check transaction status

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -2421,6 +2421,9 @@ definitions:
     title: StartSpidSessionRequest
   Transaction:
     type: object
+    required:
+        - idPayment
+        - token
     properties:
       accountingStatus:
         type: integer
@@ -2510,6 +2513,10 @@ definitions:
     title: TransactionResponse
   TransactionStatus:
     type: object
+    required:
+        - idPayment
+        - idStatus
+        - idTransaction
     properties:
       acsUrl:
         type: string
@@ -2536,6 +2543,8 @@ definitions:
     title: TransactionStatus
   TransactionStatusResponse:
     type: object
+    required:
+      - data
     properties:
       data:
         $ref: '#/definitions/TransactionStatus'
@@ -2787,8 +2796,6 @@ definitions:
     title: WalletRequest
   WalletResponse:
     type: object
-    required:
-      - data
     properties:
       data:
         $ref: '#/definitions/Wallet'

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -2797,7 +2797,7 @@ definitions:
   WalletResponse:
     type: object
     required:
-        - data
+      - data
     properties:
       data:
         $ref: '#/definitions/Wallet'

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -2796,6 +2796,8 @@ definitions:
     title: WalletRequest
   WalletResponse:
     type: object
+    required:
+        - data
     properties:
       data:
         $ref: '#/definitions/Wallet'

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,16 +1,19 @@
 import { Millisecond } from 'italia-ts-commons/lib/units';
 import { DeferredPromise } from 'italia-ts-commons/lib/promises';
-import { fromNullable } from 'fp-ts/lib/Option';
-import { fromLeft, fromPredicate, taskEither, TaskEither, tryCatch } from 'fp-ts/lib/TaskEither';
 import { Client, createClient } from '../generated/definitions/pagopa/client';
 import { TransactionStatusResponse } from '../generated/definitions/pagopa/TransactionStatusResponse';
-import { Transaction } from '../generated/definitions/pagopa/Transaction';
 import idpayguard from './js/idpayguard';
 import { initHeader } from './js/header';
 import { setTranslateBtns } from './js/translateui';
 import { initDropdowns } from './js/dropdowns';
 import { constantPollingWithPromisePredicateFetch, retryingFetch } from './utils/fetch';
-import { GENERIC_STATUS, TX_ACCEPTED, UNKNOWN } from './utils/TransactionStatesTypes';
+import {
+  checkStatusTask,
+  getDataFromSessionStorageTask,
+  isNot3dsFlowTask,
+  showErrorStatus,
+  showSuccessStatus,
+} from './utils/transactionHelper';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 document.addEventListener('DOMContentLoaded', async () => {
@@ -39,58 +42,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     fetchApi: retryingFetch(fetch, 2000 as Millisecond, 3),
   });
 
-  const checkStatusTask = (
-    transactionId: string,
-    paymentManagerClient: Client,
-  ): TaskEither<UNKNOWN, TransactionStatusResponse> =>
-    tryCatch(
-      () =>
-        paymentManagerClient.checkStatusUsingGET({
-          id: transactionId,
-        }),
-      () => UNKNOWN.value,
-    ).foldTaskEither(
-      err => fromLeft(err),
-      errorOrResponse =>
-        errorOrResponse.fold(
-          () => fromLeft(UNKNOWN.value),
-          responseType => (responseType.status !== 200 ? fromLeft(UNKNOWN.value) : taskEither.of(responseType.value)),
-        ),
-    );
-
-  const getDataFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, Transaction> =>
-    Transaction.decode(JSON.parse(fromNullable(sessionStorage.getItem(key)).getOrElse(''))).fold(
-      _ => fromLeft(UNKNOWN.value),
-      transaction => taskEither.of(transaction),
-    );
-
-  const isNot3dsFlowTask = (
-    transactionStatusResponse: TransactionStatusResponse,
-  ): TaskEither<UNKNOWN, TransactionStatusResponse> =>
-    fromPredicate(
-      (transaction: TransactionStatusResponse) => fromNullable(transaction.data?.acsUrl).isNone(),
-      _ => UNKNOWN.value,
-    )(transactionStatusResponse);
-
-  const showErrorStatus = () => {
-    document.body.classList.remove('loadingOperations');
-    document
-      .querySelectorAll('[data-response]')
-      .forEach(i => (i.getAttribute('data-response') == '3' ? null : i.remove()));
-    //To improve
-  };
-
-  const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
-    document.body.classList.remove('loadingOperations');
-    console.log(idStatus);
-    TX_ACCEPTED.decode(idStatus).map(_ =>
-      document
-        .querySelectorAll('[data-response]')
-        .forEach(i => (i.getAttribute('data-response') == '1' ? null : i.remove())),
-    );
-    // To improve
-  };
-
   document.body.classList.add('loadingOperations');
 
   // idpayguard
@@ -116,15 +67,18 @@ document.addEventListener('DOMContentLoaded', async () => {
   getDataFromSessionStorageTask('payment')
     .chain(transaction => checkStatusTask(transaction.token, paymentManagerClient))
     .chain(transactionStatusResponse => isNot3dsFlowTask(transactionStatusResponse))
-    .chain(transactionStatusResponse =>
-      checkStatusTask(
-        Buffer.from(transactionStatusResponse.data.idTransaction.toString()).toString('base64'),
-        paymentManagerClientWithPolling,
-      ),
-    )
     .fold(
-      _ => showErrorStatus(),
-      transactionStatusResponse => showSuccessStatus(transactionStatusResponse.data.idStatus),
+      _ => showErrorStatus(), // 3ds case
+      transactionStatusResponse =>
+        checkStatusTask(
+          Buffer.from(transactionStatusResponse.data.idTransaction.toString()).toString('base64'),
+          paymentManagerClientWithPolling,
+        )
+          .fold(
+            _ => showErrorStatus(),
+            transactionStatusResponse => showSuccessStatus(transactionStatusResponse.data.idStatus),
+          )
+          .run(),
     )
     .run();
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,12 +1,97 @@
+import { Millisecond } from 'italia-ts-commons/lib/units';
+import { DeferredPromise } from 'italia-ts-commons/lib/promises';
+import { fromNullable } from 'fp-ts/lib/Option';
+import { fromLeft, fromPredicate, taskEither, TaskEither, tryCatch } from 'fp-ts/lib/TaskEither';
+import { Client, createClient } from '../generated/definitions/pagopa/client';
+import { TransactionStatusResponse } from '../generated/definitions/pagopa/TransactionStatusResponse';
+import { Transaction } from '../generated/definitions/pagopa/Transaction';
 import idpayguard from './js/idpayguard';
 import { initHeader } from './js/header';
 import { setTranslateBtns } from './js/translateui';
 import { initDropdowns } from './js/dropdowns';
+import { constantPollingWithPromisePredicateFetch, retryingFetch } from './utils/fetch';
+import { GENERIC_STATUS, TX_ACCEPTED, UNKNOWN } from './utils/TransactionStatesTypes';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 document.addEventListener('DOMContentLoaded', async () => {
-  // TO UNCOMMENT
-  // document.body.classList.add('loadingOperations');
+  const retries: number = 10;
+  const delay: number = 3000;
+  const timeout: Millisecond = 20000 as Millisecond;
+
+  const isTransientErrorGivenFinalStatus = async (response: Response): Promise<boolean> => {
+    const transactionStatus = TransactionStatusResponse.encode(await response.clone().json());
+    return response.status === 200 && transactionStatus.data?.finalStatus === false;
+  };
+
+  const paymentManagerClientWithPolling: Client = createClient({
+    baseUrl: 'http://localhost:8080',
+    fetchApi: constantPollingWithPromisePredicateFetch(
+      DeferredPromise<boolean>().e1,
+      retries,
+      delay,
+      timeout,
+      isTransientErrorGivenFinalStatus,
+    ),
+  });
+
+  const paymentManagerClient = createClient({
+    baseUrl: 'http://localhost:8080',
+    fetchApi: retryingFetch(fetch, 2000 as Millisecond, 3),
+  });
+
+  const checkStatusTask = (
+    transactionId: string,
+    paymentManagerClient: Client,
+  ): TaskEither<UNKNOWN, TransactionStatusResponse> =>
+    tryCatch(
+      () =>
+        paymentManagerClient.checkStatusUsingGET({
+          id: transactionId,
+        }),
+      () => UNKNOWN.value,
+    ).foldTaskEither(
+      err => fromLeft(err),
+      errorOrResponse =>
+        errorOrResponse.fold(
+          () => fromLeft(UNKNOWN.value),
+          responseType => (responseType.status !== 200 ? fromLeft(UNKNOWN.value) : taskEither.of(responseType.value)),
+        ),
+    );
+
+  const getDataFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, Transaction> =>
+    Transaction.decode(JSON.parse(fromNullable(sessionStorage.getItem(key)).getOrElse(''))).fold(
+      _ => fromLeft(UNKNOWN.value),
+      transaction => taskEither.of(transaction),
+    );
+
+  const isNot3dsFlowTask = (
+    transactionStatusResponse: TransactionStatusResponse,
+  ): TaskEither<UNKNOWN, TransactionStatusResponse> =>
+    fromPredicate(
+      (transaction: TransactionStatusResponse) => fromNullable(transaction.data?.acsUrl).isNone(),
+      _ => UNKNOWN.value,
+    )(transactionStatusResponse);
+
+  const showErrorStatus = () => {
+    document.body.classList.remove('loadingOperations');
+    document
+      .querySelectorAll('[data-response]')
+      .forEach(i => (i.getAttribute('data-response') == '3' ? null : i.remove()));
+    //To improve
+  };
+
+  const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
+    document.body.classList.remove('loadingOperations');
+    console.log(idStatus);
+    TX_ACCEPTED.decode(idStatus).map(_ =>
+      document
+        .querySelectorAll('[data-response]')
+        .forEach(i => (i.getAttribute('data-response') == '1' ? null : i.remove())),
+    );
+    // To improve
+  };
+
+  document.body.classList.add('loadingOperations');
 
   // idpayguard
   idpayguard();
@@ -27,10 +112,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     // eslint-disable-next-line functional/immutable-data
     (el as HTMLElement).innerText = useremail;
   }
+
+  getDataFromSessionStorageTask('payment')
+    .chain(transaction => checkStatusTask(transaction.token, paymentManagerClient))
+    .chain(transactionStatusResponse => isNot3dsFlowTask(transactionStatusResponse))
+    .chain(transactionStatusResponse =>
+      checkStatusTask(
+        Buffer.from(transactionStatusResponse.data.idTransaction.toString()).toString('base64'),
+        paymentManagerClientWithPolling,
+      ),
+    )
+    .fold(
+      _ => showErrorStatus(),
+      transactionStatusResponse => showSuccessStatus(transactionStatusResponse.data.idStatus),
+    )
+    .run();
+
   // clear sessionStorage
   sessionStorage.clear();
-
-  // CALL TO PM HERE
-  // when ended uncomment...
-  // document.body.classList.remove('loadingOperations');
 });

--- a/src/response.ts
+++ b/src/response.ts
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     (el as HTMLElement).innerText = useremail;
   }
 
-  getDataFromSessionStorageTask('payment')
+  await getDataFromSessionStorageTask('payment')
     .chain(transaction => checkStatusTask(transaction.token, paymentManagerClient))
     .chain(transactionStatusResponse => isNot3dsFlowTask(transactionStatusResponse))
     .fold(

--- a/src/utils/TransactionStatesTypes.ts
+++ b/src/utils/TransactionStatesTypes.ts
@@ -1,0 +1,64 @@
+import * as t from 'io-ts';
+
+export const TX_TO_BE_AUTHORIZED = t.literal(0);
+export type TX_TO_BE_AUTHORIZED = t.TypeOf<typeof TX_TO_BE_AUTHORIZED>;
+
+export const TX_PROCESSING = t.literal(1);
+export type TX_PROCESSING = t.TypeOf<typeof TX_PROCESSING>;
+
+export const TX_PROCESSING_MOD1 = t.literal(2);
+export type TX_PROCESSING_MOD1 = t.TypeOf<typeof TX_PROCESSING_MOD1>;
+
+export const TX_ACCEPTED = t.literal(3);
+export type TX_ACCEPTED = t.TypeOf<typeof TX_ACCEPTED>;
+
+export const TX_REFUSED = t.literal(4);
+export type TX_REFUSED = t.TypeOf<typeof TX_REFUSED>;
+
+export const TX_WAIT_FOR_3DS = t.literal(5);
+export type TX_WAIT_FOR_3DS = t.TypeOf<typeof TX_WAIT_FOR_3DS>;
+
+export const TX_ERROR = t.literal(6);
+export type TX_ERROR = t.TypeOf<typeof TX_ERROR>;
+
+export const TX_RESUMING_3DS = t.literal(7);
+export type TX_RESUMING_3DS = t.TypeOf<typeof TX_RESUMING_3DS>;
+
+export const TX_ACCEPTED_MOD1 = t.literal(8);
+export type TX_ACCEPTED_MOD1 = t.TypeOf<typeof TX_ACCEPTED_MOD1>;
+
+export const TX_ACCEPTED_MOD2 = t.literal(9);
+export type TX_ACCEPTED_MOD2 = t.TypeOf<typeof TX_ACCEPTED_MOD2>;
+
+export const TX_ERROR_FROM_PSP = t.literal(10);
+export type TX_ERROR_FROM_PSP = t.TypeOf<typeof TX_ERROR_FROM_PSP>;
+
+export const TX_MISSING_CALLBACK_FROM_PSP = t.literal(11);
+export type TX_MISSING_CALLBACK_FROM_PSP = t.TypeOf<typeof TX_MISSING_CALLBACK_FROM_PSP>;
+
+export const TX_DIFFERITO_MOD1 = t.literal(12);
+export type TX_DIFFERITO_MOD1 = t.TypeOf<typeof TX_DIFFERITO_MOD1>;
+
+export const TX_EXPIRED_3DS = t.literal(13);
+export type TX_EXPIRED_3DS = t.TypeOf<typeof TX_EXPIRED_3DS>;
+
+export const TX_ACCEPTED_NODO_TIMEOUT = t.literal(14);
+export type TX_ACCEPTED_NODO_TIMEOUT = t.TypeOf<typeof TX_ACCEPTED_NODO_TIMEOUT>;
+
+export const UNKNOWN = t.literal(-1);
+export type UNKNOWN = t.TypeOf<typeof UNKNOWN>;
+
+export const TX_WAIT_FOR_3DS2_ACS_METHOD = t.literal(15);
+export type TX_WAIT_FOR_3DS2_ACS_METHOD = t.TypeOf<typeof TX_WAIT_FOR_3DS2_ACS_METHOD>;
+
+export const TX_WAIT_FOR_3DS2_ACS_CHALLENGE = t.literal(16);
+export type TX_WAIT_FOR_3DS2_ACS_CHALLENGE = t.TypeOf<typeof TX_WAIT_FOR_3DS2_ACS_CHALLENGE>;
+
+export const TX_RESUME_3DS2_ACS_METHOD = t.literal(17);
+export type TX_RESUME_3DS2_ACS_METHOD = t.TypeOf<typeof TX_RESUME_3DS2_ACS_METHOD>;
+
+export const TX_RESUME_3DS2_ACS_CHALLENGE = t.literal(18);
+export type TX_RESUME_3DS2_ACS_CHALLENGE = t.TypeOf<typeof TX_RESUME_3DS2_ACS_CHALLENGE>;
+
+export const GENERIC_STATUS = t.number;
+export type GENERIC_STATUS = t.TypeOf<typeof GENERIC_STATUS>;

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -27,7 +27,7 @@ export const checkStatusTask = (
 export const getDataFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, Transaction> =>
   Transaction.decode(JSON.parse(fromNullable(sessionStorage.getItem(key)).getOrElse(''))).fold(
     _ => fromLeft(UNKNOWN.value),
-    transaction => taskEither.of(transaction),
+    data => taskEither.of(data),
   );
 
 export const isNot3dsFlowTask = (

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -1,0 +1,58 @@
+import { fromNullable } from 'fp-ts/lib/Option';
+import { fromLeft, fromPredicate, taskEither, TaskEither, tryCatch } from 'fp-ts/lib/TaskEither';
+import { Client } from '../../generated/definitions/pagopa/client';
+import { Transaction } from '../../generated/definitions/pagopa/Transaction';
+import { TransactionStatusResponse } from '../../generated/definitions/pagopa/TransactionStatusResponse';
+import { GENERIC_STATUS, TX_ACCEPTED, UNKNOWN } from './TransactionStatesTypes';
+
+export const checkStatusTask = (
+  transactionId: string,
+  paymentManagerClient: Client,
+): TaskEither<UNKNOWN, TransactionStatusResponse> =>
+  tryCatch(
+    () =>
+      paymentManagerClient.checkStatusUsingGET({
+        id: transactionId,
+      }),
+    () => UNKNOWN.value,
+  ).foldTaskEither(
+    err => fromLeft(err),
+    errorOrResponse =>
+      errorOrResponse.fold(
+        () => fromLeft(UNKNOWN.value),
+        responseType => (responseType.status !== 200 ? fromLeft(UNKNOWN.value) : taskEither.of(responseType.value)),
+      ),
+  );
+
+export const getDataFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, Transaction> =>
+  Transaction.decode(JSON.parse(fromNullable(sessionStorage.getItem(key)).getOrElse(''))).fold(
+    _ => fromLeft(UNKNOWN.value),
+    transaction => taskEither.of(transaction),
+  );
+
+export const isNot3dsFlowTask = (
+  transactionStatusResponse: TransactionStatusResponse,
+): TaskEither<UNKNOWN, TransactionStatusResponse> =>
+  fromPredicate(
+    (transaction: TransactionStatusResponse) => fromNullable(transaction.data?.acsUrl).isNone(),
+    _ => UNKNOWN.value,
+  )(transactionStatusResponse);
+
+export const showErrorStatus = () => {
+  document.body.classList.remove('loadingOperations');
+  document
+    .querySelectorAll('[data-response]')
+    .forEach(i => (i.getAttribute('data-response') == '3' ? null : i.remove()));
+  //To improve
+};
+
+export const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
+  document.body.classList.remove('loadingOperations');
+  console.log(idStatus);
+  TX_ACCEPTED.decode(idStatus).map(_ =>
+    document
+      .querySelectorAll('[data-response]')
+      .forEach(i => (i.getAttribute('data-response') == '1' ? null : i.remove())),
+  );
+  // To improve
+};

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -42,17 +42,16 @@ export const showErrorStatus = () => {
   document.body.classList.remove('loadingOperations');
   document
     .querySelectorAll('[data-response]')
-    .forEach(i => (i.getAttribute('data-response') == '3' ? null : i.remove()));
-  //To improve
+    .forEach(i => (i.getAttribute('data-response') === '3' ? null : i.remove()));
+  // To improve
 };
 
 export const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
   document.body.classList.remove('loadingOperations');
-  console.log(idStatus);
   TX_ACCEPTED.decode(idStatus).map(_ =>
     document
       .querySelectorAll('[data-response]')
-      .forEach(i => (i.getAttribute('data-response') == '1' ? null : i.remove())),
+      .forEach(i => (i.getAttribute('data-response') === '1' ? null : i.remove())),
   );
   // To improve
 };


### PR DESCRIPTION
#### Description 

The goal of this PR is to add polling to check transaction status in response page for no 3ds flow.

#### List of Changes

- fixed api spec;
- added one api invocation to check if it is 3ds flow ;
- added polling to check transaction status;

#### Motivation and Context

This PR is important to handle transaction status in no 3ds flow.

#### How Has This Been Tested?

- yarn run test
- yarn start (with local [Payment Manager](https://github.com/pagopa/pm-mock))


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
