### PR TITLE
[IOPAY-9 IOPAY-10] Added resume3ds2 challenge and final check status polling

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -2599,6 +2599,8 @@ definitions:
     title: TransactionResponse
   TransactionStatus:
     type: object
+    required:
+        - idStatus
     properties:
       acsUrl:
         type: string

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -6,7 +6,7 @@ import { TransactionStatusResponse } from '../../generated/definitions/pagopa/Tr
 import { GENERIC_STATUS, TX_ACCEPTED, UNKNOWN } from './TransactionStatesTypes';
 
 export const resumeTransactionTask = (
-  methodCompleted: 'Y' | 'N',
+  methodCompleted: 'Y' | 'N' | undefined,
   sessionToken: string,
   idTransaction: string,
   paymentManagerClient: Client,
@@ -56,13 +56,6 @@ export const getTransactionFromSessionStorageTask = (key: string): TaskEither<UN
 export const getStringFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, string> =>
   fromNullable(sessionStorage.getItem(key)).fold(fromLeft(UNKNOWN.value), data => taskEither.of(data));
 
-export const isNot3dsFlowTask = (
-  transactionStatusResponse: TransactionStatusResponse,
-): TaskEither<UNKNOWN, TransactionStatusResponse> =>
-  fromPredicate(
-    (transaction: TransactionStatusResponse) => fromNullable(transaction.data?.acsUrl).isNone(),
-    _ => UNKNOWN.value,
-  )(transactionStatusResponse);
 
 export const showErrorStatus = () => {
   document.body.classList.remove('loadingOperations');

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -56,7 +56,6 @@ export const getTransactionFromSessionStorageTask = (key: string): TaskEither<UN
 export const getStringFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, string> =>
   fromNullable(sessionStorage.getItem(key)).fold(fromLeft(UNKNOWN.value), data => taskEither.of(data));
 
-
 export const showErrorStatus = () => {
   document.body.classList.remove('loadingOperations');
   document


### PR DESCRIPTION
#### Description

This PR introduces the following 3ds2 steps:
- Method Resume after ACS;
- Final check status polling;

#### List of Changes

1. fix model spec _TransactionStatus_;
2. add invocation of method resume 3ds2 _pp-restapi_;
3. add polling transaction check _pp-restapi_ to wait final status;
4. view transaction result (simple view that must be refactored in a dedicated PR)

#### How Has This Been Tested?

Run the following command ( with pm-mock started):
- yarn start

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
