### PR TITLE
[IO-PAY-19] Removed ACS page opening in popup

### DIFF
--- a/src/utils/iframe.ts
+++ b/src/utils/iframe.ts
@@ -52,7 +52,7 @@ export function start3DS2MethodStep(threeDSMethodUrl, threeDSMethodData, myIFram
 }
 
 export function start3DS2AcsChallengeStep(acsUrl, params, container) {
-  const form = createForm('acsChallengeForm', acsUrl, container.name, params);
+  const form = createForm('acsChallengeForm', acsUrl, '_self', params);
   container.appendChild(form);
   form.submit();
 }


### PR DESCRIPTION
####

This PR removes  ACS page opening in popup in ACS redirect step.

#### List of Changes

- target form is set '_self' in order to stay on the same page.

#### How Has This Been Tested?

Run the app with: 

- `yarn start`

and in the ACS redirect step will not open a popup.

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
