### PR TITLE
[#IOPAY-17] Added final redirect to io-pay-portal or EC

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -2071,6 +2071,7 @@ definitions:
       - amount
       - id
       - idPayment
+      - urlRedirectEc
     properties:
       amount:
         $ref: '#/definitions/Amount'

--- a/src/js/sessiondata.ts
+++ b/src/js/sessiondata.ts
@@ -20,6 +20,8 @@ export async function actionsCheck() {
   const idPaymentStored: string | null = checkDataStored ? JSON.parse(checkDataStored).idPayment : null;
   const idPaymentByQS: string | null = getUrlParameter('p') !== '' ? getUrlParameter('p') : null;
   const idPayment: string | null = checkDataStored != null ? JSON.parse(checkDataStored).idPayment : idPaymentByQS;
+  const origin: string | null = getUrlParameter('origin') !== '' ? getUrlParameter('origin') : null;
+
   // Trying to avoid a new call to endpoint if we've data stored
   if (idPaymentStored === null) {
     fromNullable(idPayment).fold(
@@ -39,6 +41,10 @@ export async function actionsCheck() {
               response => {
                 if (response.status === 200) {
                   sessionStorage.setItem('checkData', JSON.stringify(response.value.data));
+                  sessionStorage.setItem(
+                    'originUrlRedirect',
+                    fromNullable(origin).getOrElse(response.value.data.urlRedirectEc),
+                  );
                 }
               },
             );

--- a/src/response.ts
+++ b/src/response.ts
@@ -17,10 +17,33 @@ import {
   getStringFromSessionStorageTask,
   resumeTransactionTask,
   checkStatusTask,
-  showErrorStatus,
-  showSuccessStatus,
 } from './utils/transactionHelper';
 import { start3DS2MethodStep, createIFrame, start3DS2AcsChallengeStep } from './utils/iframe';
+import { GENERIC_STATUS, TX_ACCEPTED } from './utils/TransactionStatesTypes';
+
+const showErrorStatus = () => {
+  document.body.classList.remove('loadingOperations');
+  document
+    .querySelectorAll('[data-response]')
+    .forEach(i => (i.getAttribute('data-response') === '3' ? null : i.remove()));
+  (document.getElementById('response__continue') as HTMLElement).setAttribute(
+    'href',
+    fromNullable(sessionStorage.getItem('originUrlRedirect')).getOrElse('#'),
+  );
+};
+
+const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
+  document.body.classList.remove('loadingOperations');
+  TX_ACCEPTED.decode(idStatus).map(_ =>
+    document
+      .querySelectorAll('[data-response]')
+      .forEach(i => (i.getAttribute('data-response') === '1' ? null : i.remove())),
+  );
+  (document.getElementById('response__continue') as HTMLElement).setAttribute(
+    'href',
+    fromNullable(sessionStorage.getItem('originUrlRedirect')).getOrElse('#'),
+  );
+};
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 document.addEventListener('DOMContentLoaded', async () => {

--- a/src/utils/transactionHelper.ts
+++ b/src/utils/transactionHelper.ts
@@ -55,21 +55,3 @@ export const getTransactionFromSessionStorageTask = (key: string): TaskEither<UN
 
 export const getStringFromSessionStorageTask = (key: string): TaskEither<UNKNOWN, string> =>
   fromNullable(sessionStorage.getItem(key)).fold(fromLeft(UNKNOWN.value), data => taskEither.of(data));
-
-export const showErrorStatus = () => {
-  document.body.classList.remove('loadingOperations');
-  document
-    .querySelectorAll('[data-response]')
-    .forEach(i => (i.getAttribute('data-response') === '3' ? null : i.remove()));
-  // To improve
-};
-
-export const showSuccessStatus = (idStatus: GENERIC_STATUS) => {
-  document.body.classList.remove('loadingOperations');
-  TX_ACCEPTED.decode(idStatus).map(_ =>
-    document
-      .querySelectorAll('[data-response]')
-      .forEach(i => (i.getAttribute('data-response') === '1' ? null : i.remove())),
-  );
-  // To improve
-};


### PR DESCRIPTION
#### Description

This PR introduces the final redirect to _Portale Pagamenti (io-pay-portal)_ or _Ente Creditore_ according to the origin of payment.

#### List of Changes

- Fixed spec to require `urlRedirectEc` in payment response;
- Added new optional query parameter `origin` on app index;
- Added new item in session storage `originUrlRedirect`.

#### Motivation and Context

The goal of this PR is to add final redirect to _Portale Pagamenti (io-pay-portal)_ or _Ente Creditore_ according to the origin of payment. 

To distinguish the two origins, a new query parameter (`origin`) has been introduced which will be present only for payments originating from _Portale Pagamenti (io-pay-portal)_.

The final redirect will be done according to `originUrlRedirect` in `sessionStorage`, which equals to:

- url of _Portale Pagamenti (io-pay-portal)_ if the query parameter `origin` is present;
- `data.urlRedirectEc` return from `GET /pp-restapi/v4/payments/:id/actions/check` otherwise;

#### How Has This Been Tested?

Run the app with  (with pm-mock started):

- `yarn start`

and open in browser:

1. _http://localhost:1234/index.html?p=idpayment&origin=http://io-api-portal/index.html_ to test final redirect to _Portale Pagamenti (io-pay-portal)_

2. _http://localhost:1234/index.html?p=idpayment_ to test final redirect to _Ente Creditore_

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
