### PR TITLE
[IOPAY-32] Conversion to string of all 3dsData fields

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         browserColorDepth: screen.colorDepth.toString(),
         browserScreenHeight: screen.height.toString(),
         browserScreenWidth: screen.width.toString(),
-        browserTZ: new Date().getTimezoneOffset(),
+        browserTZ: new Date().getTimezoneOffset().toString(),
         browserAcceptHeader: browserInfo.accept,
         browserIP: browserInfo.ip,
         browserUserAgent: navigator.userAgent,

--- a/src/check.ts
+++ b/src/check.ts
@@ -126,11 +126,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       });
 
       const threeDSData = {
-        browserJavaEnabled: navigator.javaEnabled(),
+        browserJavaEnabled: navigator.javaEnabled().toString(),
         browserLanguage: navigator.language,
-        browserColorDepth: screen.colorDepth,
-        browserScreenHeight: screen.height,
-        browserScreenWidth: screen.width,
+        browserColorDepth: screen.colorDepth.toString(),
+        browserScreenHeight: screen.height.toString(),
+        browserScreenWidth: screen.width.toString(),
         browserTZ: new Date().getTimezoneOffset(),
         browserAcceptHeader: browserInfo.accept,
         browserIP: browserInfo.ip,


### PR DESCRIPTION
#### List of Changes

-  Conversion to string of all _3dsData_ fields, in particular:
    - browserJavaEnabled (boolena -> string)
    - browserColorDepth (number -> string)
    - browserScreenHeight (number -> string)
    - browserScreenWidth (number -> string)