### PR TITLE
[IOPAY-32] Add EMVCompliantColorDepth in ThreeDSData

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -22,7 +22,7 @@ import {
 import { mixpanel } from './__mocks__/mocks';
 import { getConfigOrThrow } from './utils/config';
 import { ErrorsType, errorHandler } from './js/errorhandler';
-import { getBrowserInfoTask } from './utils/checkHelper';
+import { getBrowserInfoTask, getEMVCompliantColorDepth } from './utils/checkHelper';
 
 const iopayportalClient: IoPayPortalClient.Client = IoPayPortalClient.createClient({
   baseUrl: getConfigOrThrow().IO_PAY_FUNCTIONS_HOST,
@@ -129,12 +129,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       const threeDSData = {
         browserJavaEnabled: navigator.javaEnabled().toString(),
         browserLanguage: navigator.language,
-        browserColorDepth: '24',
+        browserColorDepth: getEMVCompliantColorDepth(screen.colorDepth).toString(),
         browserScreenHeight: screen.height.toString(),
         browserScreenWidth: screen.width.toString(),
         browserTZ: new Date().getTimezoneOffset().toString(),
-        browserAcceptHeader:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        browserAcceptHeader: browserInfo.accept,
         browserIP: browserInfo.ip,
         browserUserAgent: navigator.userAgent,
         acctID: `ACCT_${(JSON.parse(fromNullable(sessionStorage.getItem('wallet')).getOrElse('')) as Wallet).idWallet

--- a/src/utils/__test__/check.test.ts
+++ b/src/utils/__test__/check.test.ts
@@ -74,13 +74,6 @@ describe('CheckHelper', () => {
     expect(getEMVCompliantColorDepth(-1)).toEqual(48);
   });
 
-  it('should return max colorDepth if it is outside the range of EMV Compliant Colors Depth', async () => {
-    expect(getEMVCompliantColorDepth(50)).toEqual(48);
-    expect(getEMVCompliantColorDepth(49)).toEqual(48);
-    expect(getEMVCompliantColorDepth(0)).toEqual(48);
-    expect(getEMVCompliantColorDepth(-1)).toEqual(48);
-  });
-
   it('should return the maximum valid colorDepth below the given colorDepth', async () => {
     expect(getEMVCompliantColorDepth(2)).toEqual(1);
     expect(getEMVCompliantColorDepth(5)).toEqual(4);

--- a/src/utils/__test__/check.test.ts
+++ b/src/utils/__test__/check.test.ts
@@ -3,7 +3,7 @@ import nodeFetch from 'node-fetch';
 import { right } from 'fp-ts/lib/Either';
 import { Client, createClient } from '../../../generated/definitions/iopayportal/client';
 import { retryingFetch } from '../fetch';
-import { getBrowserInfoTask } from '../checkHelper';
+import { getBrowserInfoTask, getEMVCompliantColorDepth } from '../checkHelper';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any,functional/immutable-data
 (global as any).fetch = nodeFetch;
@@ -20,7 +20,7 @@ const ioPayPortalClient: Client = createClient({
 
 const browserInfo = { ip: '0.0.0.0', useragent: 'useragent', accept: 'application/json' };
 
-describe('TransactionHelper', () => {
+describe('CheckHelper', () => {
   it('should return 200 with browserInfo if GetBrowsersInfo is successfull', async () => {
     jest.spyOn(ioPayPortalClient, 'GetBrowsersInfo').mockReturnValueOnce(
       Promise.resolve(
@@ -54,5 +54,38 @@ describe('TransactionHelper', () => {
 
     expect(ioPayPortalClient.GetBrowsersInfo).toHaveBeenCalledTimes(1);
     expect(result.isLeft()).toEqual(true);
+  });
+
+  it('should return colorDepth in input if it is EMV Compliant Color Depth', async () => {
+    expect(getEMVCompliantColorDepth(1)).toEqual(1);
+    expect(getEMVCompliantColorDepth(4)).toEqual(4);
+    expect(getEMVCompliantColorDepth(8)).toEqual(8);
+    expect(getEMVCompliantColorDepth(15)).toEqual(15);
+    expect(getEMVCompliantColorDepth(16)).toEqual(16);
+    expect(getEMVCompliantColorDepth(24)).toEqual(24);
+    expect(getEMVCompliantColorDepth(32)).toEqual(32);
+    expect(getEMVCompliantColorDepth(48)).toEqual(48);
+  });
+
+  it('should return max colorDepth if it is outside the range of EMV Compliant Colors Depth', async () => {
+    expect(getEMVCompliantColorDepth(50)).toEqual(48);
+    expect(getEMVCompliantColorDepth(49)).toEqual(48);
+    expect(getEMVCompliantColorDepth(0)).toEqual(48);
+    expect(getEMVCompliantColorDepth(-1)).toEqual(48);
+  });
+
+  it('should return max colorDepth if it is outside the range of EMV Compliant Colors Depth', async () => {
+    expect(getEMVCompliantColorDepth(50)).toEqual(48);
+    expect(getEMVCompliantColorDepth(49)).toEqual(48);
+    expect(getEMVCompliantColorDepth(0)).toEqual(48);
+    expect(getEMVCompliantColorDepth(-1)).toEqual(48);
+  });
+
+  it('should return the maximum valid colorDepth below the given colorDepth', async () => {
+    expect(getEMVCompliantColorDepth(2)).toEqual(1);
+    expect(getEMVCompliantColorDepth(5)).toEqual(4);
+    expect(getEMVCompliantColorDepth(30)).toEqual(24);
+    expect(getEMVCompliantColorDepth(33)).toEqual(32);
+    expect(getEMVCompliantColorDepth(47)).toEqual(32);
   });
 });

--- a/src/utils/checkHelper.ts
+++ b/src/utils/checkHelper.ts
@@ -17,3 +17,22 @@ export const getBrowserInfoTask = (iopayportalClient: Client): TaskEither<string
             : taskEither.of(responseType.value),
       ),
   );
+
+/**
+ * This function return a EMV compliant color depth
+ * or take the maximum valid colorDepth below the given colorDepth.
+ * @param colorDepth  (number)
+ * @returns EMV compliant colorDepth (number)
+ */
+export const getEMVCompliantColorDepth = (colorDepth: number): number => {
+  const validColorsDepths: readonly number[] = [1, 4, 8, 15, 16, 24, 32, 48];
+  const maxValidColorDepthsLength: number = 48;
+
+  const maybeValidColor = validColorsDepths.includes(colorDepth)
+    ? colorDepth
+    : validColorsDepths.find(
+        (validColorDepth, index) => validColorDepth < colorDepth && colorDepth < validColorsDepths[index + 1],
+      );
+
+  return maybeValidColor === undefined ? maxValidColorDepthsLength : maybeValidColor;
+};

--- a/src/utils/checkHelper.ts
+++ b/src/utils/checkHelper.ts
@@ -25,7 +25,7 @@ export const getBrowserInfoTask = (iopayportalClient: Client): TaskEither<string
  * @returns EMV compliant colorDepth (number)
  */
 export const getEMVCompliantColorDepth = (colorDepth: number): number => {
-  const validColorsDepths: readonly number[] = [1, 4, 8, 15, 16, 24, 32, 48];
+  const validColorsDepths: Array<number> = [1, 4, 8, 15, 16, 24, 32, 48];
   const maxValidColorDepthsLength: number = 48;
 
   const maybeValidColor = validColorsDepths.includes(colorDepth)


### PR DESCRIPTION
#### List of Changes

- EMV Compliant ColorDepth in _ThreeDSData.browserColorDepth_;
- `accept` of `browsers/info` api  in  _ThreeDSData.browserAcceptHeader_;

#### Motivation and Context

The goal of this PR is to compute EMV Compliant ColorDepth to use in  _ThreeDSData.browserColorDepth_, following this logic:

- given a `colorDepth` (`screen.colorDepth`) and a list (`validColorsDepth`) of valid colors, the EMV Compliant ColorDepth is:
    - `colorDepth` if it belongs to `validColorsDepth`;
    -  the maximum valid colorDepth below the given `colorDepth`;
    - otherwise the maximum colors in `validColorsDepth`;

#### How Has This Been Tested?

- `yarn test check.test.ts`

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
