### PR TITLE
[#IOPAY-163] Decimal length 

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -85,11 +85,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (checkTotamount) {
     // eslint-disable-next-line functional/immutable-data
-    checkTotamount.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(prettyAmount || '0'))}`;
+    checkTotamount.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(
+      +(prettyAmount || '0'),
+    )}`;
   }
   if (checkTotamountButton) {
     // eslint-disable-next-line functional/immutable-data
-    checkTotamountButton.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(prettyAmount || '0'))}`;
+    checkTotamountButton.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(
+      +(prettyAmount || '0'),
+    )}`;
   }
   if (checkCreditcardname && wallet) {
     // eslint-disable-next-line functional/immutable-data

--- a/src/check.ts
+++ b/src/check.ts
@@ -85,11 +85,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (checkTotamount) {
     // eslint-disable-next-line functional/immutable-data
-    checkTotamount.innerText = `€ ${Intl.NumberFormat('it-IT').format(+(prettyAmount || '0'))}`;
+    checkTotamount.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(prettyAmount || '0'))}`;
   }
   if (checkTotamountButton) {
     // eslint-disable-next-line functional/immutable-data
-    checkTotamountButton.innerText = `€ ${Intl.NumberFormat('it-IT').format(+(prettyAmount || '0'))}`;
+    checkTotamountButton.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(prettyAmount || '0'))}`;
   }
   if (checkCreditcardname && wallet) {
     // eslint-disable-next-line functional/immutable-data

--- a/src/choosepsp.ts
+++ b/src/choosepsp.ts
@@ -141,7 +141,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       if (commissionEl) {
         // eslint-disable-next-line functional/immutable-data
-        commissionEl.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(element.commission)}`;
+        commissionEl.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(
+          element.commission,
+        )}`;
       }
       if (logoEl && element.image) {
         logoEl.setAttribute('src', element.image);

--- a/src/choosepsp.ts
+++ b/src/choosepsp.ts
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       if (commissionEl) {
         // eslint-disable-next-line functional/immutable-data
-        commissionEl.innerText = `€ ${Intl.NumberFormat('it-IT').format(element.commission)}`;
+        commissionEl.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(element.commission)}`;
       }
       if (logoEl && element.image) {
         logoEl.setAttribute('src', element.image);

--- a/src/js/header.ts
+++ b/src/js/header.ts
@@ -31,7 +31,7 @@ export function initHeader() {
     for (const el of Array.from(importo)) {
       // eslint-disable-next-line functional/immutable-data
       (el as HTMLElement).innerText = prettifiedAmount
-        ? `€ ${Intl.NumberFormat('it-IT').format(prettifiedAmount)}`
+        ? `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(prettifiedAmount)}`
         : '';
     }
   }

--- a/src/js/multiplepayment.ts
+++ b/src/js/multiplepayment.ts
@@ -38,7 +38,7 @@ export function initMultiplePayment(data) {
       }
       if (payment.importo && itemAmount) {
         // eslint-disable-next-line functional/immutable-data
-        itemAmount.innerText = `€ ${Intl.NumberFormat('it-IT').format(+(amount || '0'))}`;
+        itemAmount.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(amount || '0'))}`;
       }
       if (payment.nomePagatore && itemName) {
         // eslint-disable-next-line functional/immutable-data
@@ -50,7 +50,7 @@ export function initMultiplePayment(data) {
       }
       if (payment.importo && itemTot) {
         // eslint-disable-next-line functional/immutable-data
-        itemTot.innerText = `€ ${Intl.NumberFormat('it-IT').format(+(amount || '0'))}`;
+        itemTot.innerText = `€ ${Intl.NumberFormat('it-IT', { minimumFractionDigits: 2 }).format(+(amount || '0'))}`;
       }
       if (payment.IUV && itemIuv) {
         // eslint-disable-next-line functional/immutable-data


### PR DESCRIPTION
This PR fix a cosmetic bug which show costs only in one decimal (eg. 30,5) instead of more useful 30,50.

#### List of Changes

Added `{ minimumFractionDigits: 2 }` option to the formatter

#### Motivation and Context

Cosmetic needs.

#### How Has This Been Tested?

Linter

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
