### PR TITLE
[IOPAY-210] check origin is payportal

### DIFF
--- a/src/js/sessiondata.ts
+++ b/src/js/sessiondata.ts
@@ -19,6 +19,7 @@ import { getUrlParameter } from './urlUtilities';
 
 import { ErrorsType, errorHandler } from './errorhandler';
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export async function actionsCheck() {
   document.body.classList.add('loading');
 
@@ -27,7 +28,6 @@ export async function actionsCheck() {
     baseUrl: getConfigOrThrow().IO_PAY_PAYMENT_MANAGER_HOST,
     fetchApi: retryingFetch(fetch, 2000 as Millisecond, 3),
   });
-  // const checkData = checkdata;
 
   const checkDataStored: string | null = sessionStorage.getItem('checkData') || null;
   const idPaymentStored: string | null = checkDataStored ? JSON.parse(checkDataStored).idPayment : null;

--- a/src/js/sessiondata.ts
+++ b/src/js/sessiondata.ts
@@ -71,9 +71,10 @@ export async function actionsCheck() {
                     idPayment: response?.value?.data?.idPayment,
                     amount: response?.value?.data?.amount,
                   });
+                  const originInput = fromNullable(origin).getOrElse(response.value.data.urlRedirectEc);
                   sessionStorage.setItem(
                     'originUrlRedirect',
-                    fromNullable(origin).getOrElse(response.value.data.urlRedirectEc),
+                    originInput === 'payportal' ? 'https://paga.io.italia.it' : originInput,
                   );
                 } else {
                   window.location.replace('ko.html');


### PR DESCRIPTION
#### List of Changes

- redirect _paga.io.italia.it_ if origin is _payportal_;
   
#### Motivation and Context

The goal of this PR is to remove the url in query string and pass _payportal_ to decide the final redirect.

Note: this works even if _pay portal_ sets the url in the origin.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
