### PR TITLE
[IOPAY-240] default error if the outcome does not fit in ViewOutcomeEnum

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -35,7 +35,12 @@ import {
 import { GENERIC_STATUS, UNKNOWN } from './utils/TransactionStatesTypes';
 import { getConfigOrThrow } from './utils/config';
 import { WalletSession } from './sessionData/WalletSession';
-import { getOutcomeFromAuthcodeAndIsDirectAcquirer, OutcomeEnumType } from './utils/TransactionResultUtil';
+import {
+  getOutcomeFromAuthcodeAndIsDirectAcquirer,
+  OutcomeEnumType,
+  ViewOutcomeEnum,
+  ViewOutcomeEnumType,
+} from './utils/TransactionResultUtil';
 
 const config = getConfigOrThrow();
 
@@ -50,10 +55,11 @@ const handleFinalStatusResult = (idStatus: GENERIC_STATUS, authorizationCode?: s
 };
 
 const showFinalResult = (outcome: OutcomeEnumType) => {
+  const viewOutcome: string = ViewOutcomeEnumType.decode(outcome).getOrElse(ViewOutcomeEnum.GENERIC_ERROR).toString();
   document.body.classList.remove('loadingOperations');
   document
     .querySelectorAll('[data-response]')
-    .forEach(i => (i.getAttribute('data-response') === outcome.toString() ? null : i.remove()));
+    .forEach(i => (i.getAttribute('data-response') === viewOutcome ? null : i.remove()));
   (document.getElementById('response__continue') as HTMLElement).setAttribute(
     'href',
     fromNullable(sessionStorage.getItem('originUrlRedirect')).getOrElse('#'),

--- a/src/utils/TransactionResultUtil.ts
+++ b/src/utils/TransactionResultUtil.ts
@@ -20,6 +20,17 @@ export enum OutcomeEnum {
   INVALID_SESSION = '14',
 }
 
+export enum ViewOutcomeEnum {
+  SUCCESS = '0',
+  GENERIC_ERROR = '1',
+  AUTH_ERROR = '2',
+  INVALID_DATA = '3',
+  TIMEOUT = '4',
+  INVALID_CARD = '7',
+  CANCELED_BY_USER = '8',
+  EXCESSIVE_AMOUNT = '10',
+}
+
 export enum NexiResultCodeEnum {
   SUCCESS = '0',
   INCORRECT_PARAMS = '1',
@@ -83,6 +94,9 @@ export enum VposResultCodeEnum {
 
 export type OutcomeEnumType = t.TypeOf<typeof OutcomeEnumType>;
 export const OutcomeEnumType = enumType<OutcomeEnum>(OutcomeEnum, 'OutcomeEnumType');
+
+export type ViewOutcomeEnumType = t.TypeOf<typeof ViewOutcomeEnumType>;
+export const ViewOutcomeEnumType = enumType<ViewOutcomeEnum>(ViewOutcomeEnum, 'ViewOutcomeEnumType');
 
 export type NexiResultCodeEnumType = t.TypeOf<typeof NexiResultCodeEnumType>;
 export const NexiResultCodeEnumType = enumType<NexiResultCodeEnum>(NexiResultCodeEnum, 'NexiResultCodeEnumType');

--- a/src/utils/__test__/TransactionResultUtil.test.ts
+++ b/src/utils/__test__/TransactionResultUtil.test.ts
@@ -218,6 +218,8 @@ describe('TransactionResultUtil', () => {
     expect(ViewOutcomeEnumType.decode(OutcomeEnum.INVALID_SESSION).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
       ViewOutcomeEnum.GENERIC_ERROR,
     );
-    
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.ORDER_NOT_PRESENT).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.GENERIC_ERROR,
+    );
   });
 });

--- a/src/utils/__test__/TransactionResultUtil.test.ts
+++ b/src/utils/__test__/TransactionResultUtil.test.ts
@@ -2,6 +2,8 @@ import {
   getOutcomeFromAuthcodeAndIsDirectAcquirer,
   NexiResultCodeEnum,
   OutcomeEnum,
+  ViewOutcomeEnum,
+  ViewOutcomeEnumType,
   VposResultCodeEnum,
 } from '../TransactionResultUtil';
 
@@ -194,6 +196,24 @@ describe('TransactionResultUtil', () => {
     );
     expect(getOutcomeFromAuthcodeAndIsDirectAcquirer(VposResultCodeEnum.INCORRECT_STATUS, false)).toEqual(
       OutcomeEnum.GENERIC_ERROR,
+    );
+  });
+
+  it('should return ViewOutcomeEnum given ViewOutcome', async () => {
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.AUTH_ERROR).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.AUTH_ERROR,
+    );
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.INVALID_CARD).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.INVALID_CARD,
+    );
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.EXCESSIVE_AMOUNT).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.EXCESSIVE_AMOUNT,
+    );
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.CIRCUIT_ERROR).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.GENERIC_ERROR,
+    );
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.DUPLICATE_ORDER).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.GENERIC_ERROR,
     );
   });
 });

--- a/src/utils/__test__/TransactionResultUtil.test.ts
+++ b/src/utils/__test__/TransactionResultUtil.test.ts
@@ -215,5 +215,9 @@ describe('TransactionResultUtil', () => {
     expect(ViewOutcomeEnumType.decode(OutcomeEnum.DUPLICATE_ORDER).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
       ViewOutcomeEnum.GENERIC_ERROR,
     );
+    expect(ViewOutcomeEnumType.decode(OutcomeEnum.INVALID_SESSION).getOrElse(ViewOutcomeEnum.GENERIC_ERROR)).toEqual(
+      ViewOutcomeEnum.GENERIC_ERROR,
+    );
+    
   });
 });


### PR DESCRIPTION
#### List of Changes

- add `ViewOutcomeEnum` to model only the `outcomes` shown at the end of the _payment transaction_;

#### Motivation and Context

The goal of this PR is to show a message related to the `GENERIC_ERROR(1)` if the `outcome` is not among the following:

  - `SUCCESS(0)`;
  - `GENERIC_ERROR(1)`;
  - `AUTH_ERROR(2)`;
  - `INVALID_DATA(3)`;
  - `TIMEOUT(4)`;
  - `INVALID_CARD(7)`;
  - `CANCELED_BY_USER(8)`;
  - `EXCESSIVE_AMOUNT(10)`;

#### How Has This Been Tested?

Run app locally or the following unit test;
-` TransactionResultUtil.test.ts`

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
