### PR TITLE
[#IOPAY-307] Fix & improve of exp date field

### DIFF
--- a/src/inputcard.pug
+++ b/src/inputcard.pug
@@ -58,7 +58,7 @@ html(lang='it')
                                                         svg.icon.icon-sm
                                                             use(href="/assets/icons/sprite.svg#it-calendar")
                                                 label.sr-only(for="creditcardexpirationdate", data-lang="textField.expireDate.label") scadenza
-                                                input.form-control(type="text", placeholder="mm/aa", maxlength="5", name="creditcardexpirationdate", id="creditcardexpirationdate", required, autocomplete="cc-exp")
+                                                input.form-control(type="text", placeholder="mm/aa", maxlength="5", name="creditcardexpirationdate", id="creditcardexpirationdate", required, autocomplete="cc-exp", inputmode="numeric")
                                                 .reset-flex-flow.text-muted.mt-1.custom-label(data-lang="textField.expireDate.label", aria-hidden="true") scadenza
                                                 .reset-flex-flow.text-muted.mt-1.custom-label--error(id="creditcardexpirationdateError", aria-hidden="true", tabindex="-1") Inserisci mm/aa
                                         .col-6

--- a/src/inputcard.ts
+++ b/src/inputcard.ts
@@ -524,7 +524,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   creditcardformExpiration?.addEventListener('keyup', evt => {
     const inputel = evt?.target as HTMLInputElement;
-    if (inputel.value.length > 2 && inputel.value.indexOf('/') !== 2) {
+    if (inputel.value.length > 2 && inputel.value.indexOf('/') === -1) {
       // eslint-disable-next-line functional/immutable-data
       inputel.value = inputel.value.slice(0, 2) + '/' + inputel.value.slice(2);
     }


### PR DESCRIPTION
This PR solve two issues on the expiration date field (in inputcard screen)

#### List of Changes

- added an `inputmode=numeric` attribute to the expiration date field
- fix a bug with the "slash" contained in the value of the field

#### Motivation and Context
UX improve of the expiration date field

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
