### PR TITLE
[#IOPAY-381] Added scrollrestoration manual to avoid cache

### DIFF
--- a/src/js/sessiondata.ts
+++ b/src/js/sessiondata.ts
@@ -56,7 +56,7 @@ export async function actionsCheck() {
     ) {
       window.sessionStorage.clear();
       // eslint-disable-next-line functional/immutable-data
-      window.location.href = 'https://checkout.pagopa.it/';
+      window.location.href = '/';
     } else {
       changeUrl();
     }

--- a/src/js/sessiondata.ts
+++ b/src/js/sessiondata.ts
@@ -41,6 +41,10 @@ export async function actionsCheck() {
     // TRICK to listen when a user want use back button to leave webapp
     const actualUrl = `${window.location.origin}${window.location.pathname}`;
     history.pushState(null, '', `${actualUrl}${hashUrlName}`);
+    if ('scrollRestoration' in history) {
+      // eslint-disable-next-line functional/immutable-data
+      history.scrollRestoration = 'manual';
+    }
   }
 
   // eslint-disable-next-line functional/immutable-data


### PR DESCRIPTION
Chrome cache navigation between pages of a same domain. But we doesn't need it cause we want "alert user" about the payment cancel

#### List of Changes

Added histtory.scrollrestoration=manual after the pushstate



#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
