### PR TITLE
Make view outcome dependant on both transaction status and gateway au…

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -45,7 +45,11 @@ import {
 const config = getConfigOrThrow();
 
 const handleFinalStatusResult = (idStatus: GENERIC_STATUS, authorizationCode?: string, isDirectAcquirer?: boolean) => {
-  const outcome: OutcomeEnumType = getOutcomeFromAuthcodeAndIsDirectAcquirer(authorizationCode, isDirectAcquirer);
+  const outcome: OutcomeEnumType = getOutcomeFromAuthcodeAndIsDirectAcquirer(
+    authorizationCode,
+    isDirectAcquirer,
+    idStatus,
+  );
   mixpanel.track(PAYMENT_OUTCOME_CODE.value, {
     EVENT_ID: PAYMENT_OUTCOME_CODE.value,
     idStatus,


### PR DESCRIPTION
…th code

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

* Make view outcome dependant on both transaction status and gateway au…

#### Motivation and Context

Before, if PM answered with a status code not consistent with the payment gateway authorization code the former would be ignored and a wrong outcome would be displayed to the user. This hotfix partially solves the issue for rejection status codes for the Nexi gateway (for the cases as observed in production).

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
